### PR TITLE
Simplify bot layer

### DIFF
--- a/app/bot/bot.py
+++ b/app/bot/bot.py
@@ -1,28 +1,75 @@
 import telebot
+from io import BytesIO
+from typing import Optional
 
 from app.bot.core.access import AccessControl
-from app.bot.core.handler import CommandHandler
-from app.bot.core.interactor import Interactor
-from app.bot.core.sender import Sender
+from app.database.models import Item
 from app.service.facade import MemeOracleService
 
 
 class MemeOracleBot:
-    def __init__(self, service: MemeOracleService, token: str) -> None:
-        bot = telebot.TeleBot(token)
-        sender = Sender(bot)
-        interactor = Interactor(service)
-        access_controller = AccessControl()
-        handler = CommandHandler(bot, access_controller, interactor, sender)
+    def __init__(
+        self,
+        service: MemeOracleService,
+        token: Optional[str] = None,
+        bot: Optional[telebot.TeleBot] = None,
+        access: Optional[AccessControl] = None,
+    ) -> None:
+        self.service = service
+        self.bot = bot or telebot.TeleBot(token)
+        self.access = access or AccessControl()
+        self.send_methods = {
+            "image": self.bot.send_photo,
+            "video": self.bot.send_video,
+        }
 
-        self.bot = bot
-        self.handler = handler
-        self._register_handlers()
+    def register_handlers(self) -> None:
+        self.bot.message_handler(commands=["ask_oracle"])(self.ask_oracle)
+        self.bot.message_handler(commands=["random"])(self.random)
+        self.bot.message_handler(commands=["help"])(self.help)
 
-    def _register_handlers(self) -> None:
-        self.bot.message_handler(commands=["ask_oracle"])(self.handler.ask_oracle)
-        self.bot.message_handler(commands=["random"])(self.handler.random)
-        self.bot.message_handler(commands=["help"])(self.handler.help)
+    def _reply(self, message, text: str) -> None:
+        self.bot.reply_to(message, text)
+
+    def _send_item(self, message, item: Item) -> bool:
+        send_method = self.send_methods.get(item.type)
+        if send_method is None:
+            return False
+        file: BytesIO = self.service.get_object(item.s3_name)
+        send_method(message.chat.id, file)
+        return True
+
+    def help(self, message) -> None:
+        self._reply(message, "Ask the Oracle by using `/ask_oracle`.")
+
+    def random(self, message) -> None:
+        if not self.access.is_tester(message.from_user.id):
+            self._reply(message, "Unknown command.")
+            return
+        try:
+            item = self.service.get_random_item()
+            self._send_item(message, item)
+        except Exception:  # pylint: disable=W0718
+            self._reply(message, "Something went wrong.")
+
+    def ask_oracle(self, message) -> None:
+        user_id = message.from_user.id
+        items = self.service.get_candidate_items(user_id)
+        if items is None:
+            self._reply(message, "Oracle is tired, come back tomorrow.")
+            return
+        if not items:
+            self._reply(message, "No prophecies found.")
+            return
+        for item in items:
+            try:
+                if self._send_item(message, item):
+                    self.service.log_interaction(user_id, item.id)
+                    return
+            except Exception:  # pylint: disable=W0718
+                continue
+        self._reply(message, "Oracle is confused, try again.")
 
     def run(self) -> None:
+        self.register_handlers()
         self.bot.infinity_polling()

--- a/tests/app/bot/test_bot.py
+++ b/tests/app/bot/test_bot.py
@@ -1,0 +1,95 @@
+from io import BytesIO
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from dataclasses import dataclass
+
+import pytest
+
+sys.modules.setdefault("telebot", MagicMock())
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+fake_models = ModuleType("app.database.models")
+
+@dataclass
+class Item:
+    id: str
+    s3_name: str
+    type: str
+    upload_dt: datetime | None = None
+
+fake_models.Item = Item
+sys.modules.setdefault("app.database.models", fake_models)
+
+fake_facade = ModuleType("app.service.facade")
+
+class MemeOracleService:
+    pass
+
+fake_facade.MemeOracleService = MemeOracleService
+sys.modules.setdefault("app.service.facade", fake_facade)
+
+from app.bot.bot import MemeOracleBot
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    monkeypatch.delenv("AUTHORIZED_TESTERS_TG_IDS", raising=False)
+
+
+@pytest.fixture
+def service_mock():
+    return MagicMock()
+
+
+@pytest.fixture
+def bot_mock():
+    bot = MagicMock()
+    bot.send_photo = MagicMock()
+    bot.send_video = MagicMock()
+    bot.reply_to = MagicMock()
+    return bot
+
+
+def make_item(item_type="image"):
+    return Item(id="1", s3_name="name", type=item_type, upload_dt=datetime.now(timezone.utc))
+
+
+def test_help_sends_instructions(service_mock, bot_mock):
+    bot = MemeOracleBot(service_mock, token="t", bot=bot_mock)
+    message = MagicMock()
+
+    bot.help(message)
+
+    bot_mock.reply_to.assert_called_once_with(message, "Ask the Oracle by using `/ask_oracle`.")
+
+
+def test_random_requires_tester(monkeypatch, service_mock, bot_mock):
+    monkeypatch.setenv("AUTHORIZED_TESTERS_TG_IDS", "42")
+    message = MagicMock()
+    message.from_user.id = 99
+
+    bot = MemeOracleBot(service_mock, token="t", bot=bot_mock)
+    bot.random(message)
+
+    bot_mock.reply_to.assert_called_once_with(message, "Unknown command.")
+    bot_mock.send_photo.assert_not_called()
+
+
+def test_ask_oracle_sends_item_and_logs(service_mock, bot_mock):
+    message = MagicMock()
+    message.chat.id = 5
+    message.from_user.id = 7
+
+    item = make_item()
+    service_mock.get_candidate_items.return_value = [item]
+    service_mock.get_object.return_value = BytesIO(b"data")
+
+    bot = MemeOracleBot(service_mock, token="t", bot=bot_mock)
+    bot.ask_oracle(message)
+
+    bot_mock.send_photo.assert_called_once_with(message.chat.id, service_mock.get_object.return_value)
+    service_mock.log_interaction.assert_called_once_with(7, item.id)


### PR DESCRIPTION
## Summary
- simplify Telegram bot implementation
- add unit tests for the new bot

## Testing
- `pytest tests/app/bot/test_bot.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_6842d59a55048321b40526865ee887f7